### PR TITLE
Add RSS feed support

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -5,11 +5,14 @@ import { Layout } from "./templates/layout.ts";
 import { LayoutData } from "./types.ts";
 import { PostTemplate } from "./templates/post.ts";
 import { getCachedPosts, getPost } from "./cache.ts";
+import { generateRSSFeed } from "./rss.ts";
 
 const PORT = parseInt(Deno.env.get("PORT") || "7182");
 const BLOG_TITLE = Deno.env.get("BLOG_TITLE") || "Reginald Blog";
 const BLOG_COPYRIGHT = Deno.env.get("BLOG_COPYRIGHT") ||
   "© 2025 John L. Carveth";
+const BASE_URL = Deno.env.get("BASE_URL") || "https://blog.jlcarveth.dev";
+const BLOG_DESCRIPTION = Deno.env.get("BLOG_DESCRIPTION") || "A personal blog about technology, programming, and software development";
 
 /* Define root route that lists blog posts */
 async function serveIndex() {
@@ -118,6 +121,30 @@ get("/post/:slug", async (_req, _path, params) => {
 
   return new Response(Layout(data), {
     headers: { "Content-Type": "text/html" },
+  });
+});
+
+/* RSS Feed Route */
+get("/rss.xml", async () => {
+  const posts = await getCachedPosts();
+  
+  const rssXML = generateRSSFeed(posts, {
+    title: BLOG_TITLE,
+    description: BLOG_DESCRIPTION,
+    link: BASE_URL,
+    language: "en-us",
+    copyright: BLOG_COPYRIGHT,
+    managingEditor: "john@jlcarveth.dev (John L. Carveth)",
+    webMaster: "john@jlcarveth.dev (John L. Carveth)",
+    lastBuildDate: new Date(),
+    ttl: 60, // 60 minutes
+  });
+
+  return new Response(rssXML, {
+    headers: { 
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control": "max-age=3600", // Cache for 1 hour
+    },
   });
 });
 

--- a/rss.ts
+++ b/rss.ts
@@ -1,0 +1,78 @@
+import { Post } from "./types.ts";
+
+interface RSSFeedOptions {
+  title: string;
+  description: string;
+  link: string;
+  language?: string;
+  copyright?: string;
+  managingEditor?: string;
+  webMaster?: string;
+  lastBuildDate?: Date;
+  ttl?: number;
+}
+
+interface RSSItem {
+  title: string;
+  description: string;
+  link: string;
+  pubDate: Date;
+  guid: string;
+  author?: string;
+}
+
+export function generateRSSFeed(posts: Post[], options: RSSFeedOptions): string {
+  const { title, description, link, language = "en-us", copyright, managingEditor, webMaster, lastBuildDate, ttl } = options;
+  
+  // Convert posts to RSS items
+  const rssItems: RSSItem[] = posts
+    .filter(post => post.publish_date) // Only include published posts
+    .map(post => ({
+      title: post.title || "Untitled",
+      description: post.description || post.contentPreview || "",
+      link: `${link}/post/${post.name}`,
+      pubDate: new Date(post.publish_date!),
+      guid: `${link}/post/${post.name}`,
+      author: post.author || managingEditor || "",
+    }));
+
+  // Sort items by publication date (newest first)
+  rssItems.sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime());
+
+  // Generate RSS XML
+  const rssXML = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>${escapeXML(title)}</title>
+    <description>${escapeXML(description)}</description>
+    <link>${escapeXML(link)}</link>
+    <language>${language}</language>
+    <lastBuildDate>${(lastBuildDate || new Date()).toUTCString()}</lastBuildDate>
+    <generator>Reginald Blog</generator>
+    ${copyright ? `<copyright>${escapeXML(copyright)}</copyright>` : ''}
+    ${managingEditor ? `<managingEditor>${escapeXML(managingEditor)}</managingEditor>` : ''}
+    ${webMaster ? `<webMaster>${escapeXML(webMaster)}</webMaster>` : ''}
+    ${ttl ? `<ttl>${ttl}</ttl>` : ''}
+    ${rssItems.map(item => `
+    <item>
+      <title>${escapeXML(item.title)}</title>
+      <description>${escapeXML(item.description)}</description>
+      <link>${escapeXML(item.link)}</link>
+      <pubDate>${item.pubDate.toUTCString()}</pubDate>
+      <guid isPermaLink="true">${escapeXML(item.guid)}</guid>
+      ${item.author ? `<author>${escapeXML(item.author)}</author>` : ''}
+    </item>`).join('')}
+  </channel>
+</rss>`;
+
+  return rssXML;
+}
+
+function escapeXML(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;');
+}

--- a/rss.ts
+++ b/rss.ts
@@ -18,7 +18,6 @@ interface RSSItem {
   link: string;
   pubDate: Date;
   guid: string;
-  author?: string;
 }
 
 export function generateRSSFeed(posts: Post[], options: RSSFeedOptions): string {
@@ -33,7 +32,6 @@ export function generateRSSFeed(posts: Post[], options: RSSFeedOptions): string 
       link: `${link}/post/${post.name}`,
       pubDate: new Date(post.publish_date!),
       guid: `${link}/post/${post.name}`,
-      author: post.author || managingEditor || "",
     }));
 
   // Sort items by publication date (newest first)
@@ -60,7 +58,6 @@ export function generateRSSFeed(posts: Post[], options: RSSFeedOptions): string 
       <link>${escapeXML(item.link)}</link>
       <pubDate>${item.pubDate.toUTCString()}</pubDate>
       <guid isPermaLink="true">${escapeXML(item.guid)}</guid>
-      ${item.author ? `<author>${escapeXML(item.author)}</author>` : ''}
     </item>`).join('')}
   </channel>
 </rss>`;

--- a/templates/layout.ts
+++ b/templates/layout.ts
@@ -38,6 +38,9 @@ export function Layout(data: LayoutData) {
     <meta name="twitter:description" content="${ogDescription}">
     ${ogImage ? `<meta name="twitter:image" content="${ogImage}">` : ''}
     
+    <!-- RSS Feed -->
+    <link rel="alternate" type="application/rss+xml" title="RSS Feed" href="/rss.xml">
+    
     ${plausibleScript()}
     ${data.stylesheets?.join("\n") ?? ""}
   </head>


### PR DESCRIPTION
## Summary
• Added RSS feed generation module with RSS 2.0 compliant XML output
• Implemented `/rss.xml` endpoint with proper caching headers
• Added RSS autodiscovery link to HTML head for feed readers
• Fixed RSS validation by removing author field (requires email format)

## Test plan
- [ ] Visit `/rss.xml` and verify RSS feed loads properly
- [ ] Test RSS feed with an RSS reader or validator
- [ ] Verify RSS autodiscovery works in browsers
- [ ] Check that only published posts appear in the feed

🤖 Generated with [Claude Code](https://claude.ai/code)